### PR TITLE
fix: cannot create warnings on profiles

### DIFF
--- a/src/Api/Controller/CreateWarningController.php
+++ b/src/Api/Controller/CreateWarningController.php
@@ -55,7 +55,7 @@ class CreateWarningController extends AbstractCreateController
         $actor->assertCan('user.manageWarnings');
 
         $requestData = $request->getParsedBody()['data']['attributes'];
-        $requestRelationships = $request->getParsedBody()['data']['relationships'];
+        $requestRelationships = $request->getParsedBody()['data']['relationships'] ?? [];
 
         $publicComment = $requestData['public_comment'];
 


### PR DESCRIPTION
When you try to create a warning on a user profile it errors because there are no relationships in the payload. This PR fixes that without too many changes.