### PR TITLE
fix(routing): use slug for routing on UserPage

### DIFF
--- a/js/src/forum/addWarningPage.js
+++ b/js/src/forum/addWarningPage.js
@@ -19,7 +19,7 @@ export default function () {
         LinkButton.component(
           {
             href: app.route('user.warnings', {
-              username: this.user.username(),
+              username: this.user.slug(),
             }),
             icon: 'fas fa-exclamation-circle',
           },


### PR DESCRIPTION
Summary:
- Use slug instead of username for better compatibility when the slug driver is set to id or default